### PR TITLE
Adaptation des CSS pour un affichage dans un portail (ESUP par exemple) avec 2 colonnes

### DIFF
--- a/apps/frontend/templates/layout.php
+++ b/apps/frontend/templates/layout.php
@@ -12,7 +12,7 @@
     <script type="text/javascript">
     function checkPortal() {
 	if (top.location != self.document.location) {
-		// if filez is displayed through a web portal hide logos and logout box
+		// if rdvz is displayed through a web portal hide logos and logout box
 		document.getElementById('logo').style.display = 'none';
 	}
 } 

--- a/apps/frontend/templates/layout.php
+++ b/apps/frontend/templates/layout.php
@@ -14,6 +14,9 @@
 	if (top.location != self.document.location) {
 		// if rdvz is displayed through a web portal hide logos and logout box
 		document.getElementById('logo').style.display = 'none';
+		document.getElementById('logout_button').style.display = 'none';
+	} else {
+		document.getElementById('back_home').style.display = 'none';
 	}
 } 
     </script>
@@ -46,7 +49,8 @@
         <?php endforeach ; ?>
         <?php echo mail_to('romain.deveaud@univ-avignon.fr', '<img src="'.image_path('/images/71.png').'" alt="Bug" /> '.__('Signaler un bogue')) ?>
         <?php echo link_to('<img src="'.image_path('/images/51.png').'" alt="Help" /> '.__('Aide'), url_for('help'), array('popup' => array('RdvZ '.__('Aide'),'left=320,top=200,width=1000,height=700,scrollbars=yes'))) ?>
-        <?php echo link_to('<img src="'.image_path('/images/shutdown.png').'" alt="'.__('Déconnexion').'" title="'.__('Déconnexion').'" />', 'out') ?>
+        <?php echo link_to('<img src="'.image_path('/images/shutdown.png').'" alt="'.__('Déconnexion').'" title="'.__('Déconnexion').'" id="logout_button" />', 'out') ?>
+	<?php echo link_to('<span id="back_home">Accueil<span>', 'homepage') ?>
       </div>
     <?php endif ; ?>
     <div id="footer">

--- a/apps/frontend/templates/layout.php
+++ b/apps/frontend/templates/layout.php
@@ -9,11 +9,19 @@
       <?php endif; ?>
     </title>
     <script type="text/javascript" src="<?php echo javascript_path('jquery-1.4.2.min.js') ?>"></script>
+    <script type="text/javascript">
+    function checkPortal() {
+	if (top.location != self.document.location) {
+		// if filez is displayed through a web portal hide logos and logout box
+		document.getElementById('logo').style.display = 'none';
+	}
+} 
+    </script>
     <?php include_http_metas() ?>
     <?php include_metas() ?>
     <?php include_stylesheets() ?>
   </head>
-  <body>
+  <body onLoad="checkPortal();">
     <?php echo link_to('<img src="'.image_path('/images/rdvz_logo3_final.png').'" id="logo" />','homepage') ?>
 <!--    <div id="menu">
     </div> -->

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -46,7 +46,7 @@ right: 0px;
 bottom: 0px;
 left: 0px;
 /*  width:650px;*/
-width:95% ;
+width:90% ;
 height: 100%;
 margin: auto;
 border : 1px solid #B9B9B9 ;
@@ -140,7 +140,8 @@ width : 250px ;
 
 #meeting_infos {
 letter-spacing: -1px ;
-margin-bottom : 15px ;        
+margin-bottom : 15px ;
+margin-top : 15px;  
 }
 
 #meeting_infos #meeting_title {
@@ -220,7 +221,7 @@ padding : 0px ;
 margin : 0px ;          
 list-style: none ;
 float : left ;
-width : 700px ;        
+width : 100%;        
 letter-spacing : -1px ;
 }
 
@@ -301,9 +302,10 @@ display : none ;
 }
 
 ul.my_meetings li .actions a {
-padding-left : 10px ;  
-padding-right : 10px ;  
+padding-left : 6px ;  
+padding-right : 6px ;  
 border-left : 1px solid #d8d8d8 ;
+font-size:0.9em;
 }
 
 ul.my_meetings li .actions a.no_border {
@@ -380,17 +382,15 @@ text-align : justify ;
 }
 
 #meet_disc_box {
-position : absolute ;
 top : 10px ;
-left : 200px ;      
 }
 
 #url_meet_disc {
 color: #777;
-font-size: 1.5em;
+font-size: 1.1em;
 letter-spacing: -0.1em ;
 margin-bottom : 7px ;
-margin-left : -10px ;
+margin-left : 0px ;
 text-shadow: 1px 1px 1px #ddd ;
 }
 
@@ -401,9 +401,8 @@ font-size : 1.4em ;
 #m_search {
 background: transparent url('../images/search.png') no-repeat 0px 0px;  
 color: #777;
-width: 525px;
+width: 85%;
 margin-bottom : 20px ;
-margin-left : 20px ;
 }
 
 .error_name {
@@ -411,15 +410,15 @@ border : 4px solid #a00000;
 }
 
 .search {
-font-size: 1.5em;
+font-size: 1.3em;
 height: 33px;
-padding: 7px 50px 0px;
+padding: 7px 20px 0px 50px;
 }
 
 .url_meet {
 color: #777;
-width: 450px;
-padding : 7px 30px 0px ;       
+width: 100%;
+padding : 7px 0px 0px 7px;       
 }
 
 .comment_present {

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -117,7 +117,7 @@ padding-bottom : 7px ;
 -webkit-box-shadow: inset 0 -4px 4px rgba(0,0,0,0.05);
 }
 
-#user_infos img {
+#user_infos img, #user_infos span#back_home {
 margin-left : 3px ;
 margin-bottom : -4px ;
 border-left : 1px solid #d8d8d8 ;


### PR DESCRIPTION
Bonjour,
j'ai fait des petites modifications des CSS de RdvZ pour que l'affichage s'adapte mieux à une iframe de taille réduite.
Je me suis inspiré de ce qui a été fait par @rouanet sur filez pour masquer le logo lorsqu'on est affiché dans un portail. J'ai aussi modifié les CSS, et notamment les largeurs pour les passer en relatif, afin que l'affichage ne déborde pas lorsqu'on est dans une iframe trop petite.
